### PR TITLE
[BUGFIX] Fix OrderItemsController invocation

### DIFF
--- a/packages/hofexpress_app/Classes/Controller/OrderItemsController.php
+++ b/packages/hofexpress_app/Classes/Controller/OrderItemsController.php
@@ -2,6 +2,7 @@
 namespace Hulk\HofexpressApp\Controller;
 
 use Hulk\HofexpressApp\Domain\Model\Customer;
+use Hulk\HofexpressApp\Domain\Model\OrderItems;
 use OliverHader\SessionService\InvalidSessionException;
 use OliverHader\SessionService\SubjectCollection;
 use OliverHader\SessionService\SubjectResolver;
@@ -24,14 +25,14 @@ class OrderItemsController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
 
     /**
      * orderItemsRepository
-     * 
+     *
      * @var \Hulk\HofexpressApp\Domain\Repository\OrderItemsRepository
      */
     protected $orderItemsRepository = null;
 
     /**
      * action list
-     * 
+     *
      * @return void
      */
     public function listAction()
@@ -70,7 +71,7 @@ class OrderItemsController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
     }
     /**
      * action new
-     * 
+     *
      * @return void
      */
     public function newAction()
@@ -79,11 +80,11 @@ class OrderItemsController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
 
     /**
      * action create
-     * 
+     *
      * @param \Hulk\Hofexpress\Domain\Model\OrderItems $newOrderItems
      * @return void
      */
-    public function createAction(\Hulk\Hofexpress\Domain\Model\OrderItems $newOrderItems)
+    public function createAction(\Hulk\HofexpressApp\Domain\Model\OrderItems $newOrderItems)
     {
         $this->orderItemsRepository->add($newOrderItems);
         $this->redirect('show');
@@ -91,23 +92,23 @@ class OrderItemsController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
 
     /**
      * action edit
-     * 
+     *
      * @param \Hulk\HofexpressApp\Domain\Model\OrderItems $orderItems
      * @ignorevalidation $orderItems
      * @return void
      */
-    public function editAction(\Hulk\Hofexpress\Domain\Model\OrderItems $orderItems)
+    public function editAction(\Hulk\HofexpressApp\Domain\Model\OrderItems $orderItems)
     {
         $this->view->assign('orderItems', $orderItems);
     }
 
     /**
      * action update
-     * 
+     *
      * @param \Hulk\HofexpressApp\Domain\Model\OrderItems $orderItems
      * @return void
      */
-    public function updateAction(\Hulk\Hofexpress\Domain\Model\OrderItems $orderItems)
+    public function updateAction(\Hulk\HofexpressApp\Domain\Model\OrderItems $orderItems)
     {
         $this->addFlashMessage('The object was updated. Please be aware that this action is publicly accessible unless you implement an access check. See https://docs.typo3.org/typo3cms/extensions/extension_builder/User/Index.html', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::WARNING);
         $this->orderItemsRepository->update($orderItems);
@@ -116,11 +117,11 @@ class OrderItemsController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
 
     /**
      * action delete
-     * 
+     *
      * @param \Hulk\HofexpressApp\Domain\Model\OrderItems $orderItems
      * @return void
      */
-    public function deleteAction(\Hulk\Hofexpress\Domain\Model\OrderItems $orderItems)
+    public function deleteAction(\Hulk\HofexpressApp\Domain\Model\OrderItems $orderItems)
     {
         $this->addFlashMessage('The object was deleted. Please be aware that this action is publicly accessible unless you implement an access check. See https://docs.typo3.org/typo3cms/extensions/extension_builder/User/Index.html', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::WARNING);
         $this->orderItemsRepository->remove($orderItems);

--- a/packages/hofexpress_app/Classes/Domain/Model/Customer.php
+++ b/packages/hofexpress_app/Classes/Domain/Model/Customer.php
@@ -21,7 +21,7 @@ class Customer extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * userId
      * 
-     * @var TYPO3\CMS\Extbase\Domain\Model\FrontendUser
+     * @var \TYPO3\CMS\Extbase\Domain\Model\FrontendUser
      * @TYPO3\CMS\Extbase\Annotation\Validate("NotEmpty")
      */
     protected $userId = 0;

--- a/packages/hofexpress_app/Configuration/TypoScript/setup.typoscript
+++ b/packages/hofexpress_app/Configuration/TypoScript/setup.typoscript
@@ -1,4 +1,4 @@
-plugin.tx_hofexpressapp_hofexpress {
+plugin.tx_hofexpressapp {
     view {
         templateRootPaths.0 = EXT:hofexpress_app/Resources/Private/Templates/
         templateRootPaths.1 = {$plugin.tx_hofexpressapp_hofexpress.view.templateRootPath}

--- a/packages/hofexpress_app/Resources/Private/Templates/Restaurant/Show.html
+++ b/packages/hofexpress_app/Resources/Private/Templates/Restaurant/Show.html
@@ -92,7 +92,7 @@ Otherwise your changes will be overwritten the next time you save the extension 
                 </td>
                 <td>
                         <f:link.action action="show"  class="btn btn-info" arguments="{orderItems:orderItems}"
-                                       git ="OrderItems"
+                                       controller="OrderItems"
                                        pageUid="{settings.pages.orderItems}" pluginName="OrderPlugin">
                             Add to Cart
                         </f:link.action>


### PR DESCRIPTION
* use proper PHP namespace `Hofexpress` vs `HofexpressApp`
* use `plugin.tx_hofexpressapp` instead of `plugin.tx_hofexpressapp_hofexpress`
  + `plugin.tx_hofexpressapp` defines (now) settings for all plugins of the extension
  + `plugin.tx_hofexpressapp_hofexpress` just concerned the (previous) `Hofexpress` plugin of this extension